### PR TITLE
set up new method to check enemy deaths

### DIFF
--- a/assets/cheat_mode.rb
+++ b/assets/cheat_mode.rb
@@ -7,15 +7,15 @@ def cheat_menu(player, enemies)
   case player[:choice]
   when 'j' then enemies.first[:hp] -= 40
   when 'k' then enemies << random_enemy
-  when "n" then player[:hp] -= 40
-  when "m" then player[:hp] += 100
-  when "v" then player[:cash] -= 1
-  when "c" then player[:cash] += 1
+  when "n" then player[:hp]    -= 40
+  when "m" then player[:hp]    += 100
+  when "v" then player[:cash]  -= 1
+  when "c" then player[:cash]  += 1
   when "f" then player[:drunk] -= 1
   when "d" then player[:drunk] += 1
-  when "2" then player[:uses] += 1 if player[:equipped]
-  when "1" then player[:uses] -= 1 if player[:equipped]
-  when "0" then player[:uses]  = 0 if player[:equipped]
+  when "2" then player[:uses]  += 1 if player[:equipped]
+  when "1" then player[:uses]  -= 1 if player[:equipped]
+  when "0" then player[:uses]   = 0 if player[:equipped]
   when "w" then equip_weapon(player)
   when "e" then equip_weapon(enemies.sample)
   when "b" then weapon_breaks(player)
@@ -25,5 +25,4 @@ def cheat_menu(player, enemies)
   player[:uses] = player[:uses].clamp(0, 5) if player[:equipped]
   player[:drunk] = player[:drunk].clamp(0, 5)
   player[:cash] = player[:cash].clamp(0, 5)
-  return enemies
 end

--- a/interface.rb
+++ b/interface.rb
@@ -34,19 +34,8 @@ def play_game
       error(:input)
     end
 
-    # enemies.reject! do |enemy|
-    #   if enemy[:hp] <= 0  # check for enemy deaths, update counter, track last enemy for game over
-    #     player[:kills] += 1
-    #     enemy_speaks(enemy, :pwned)
-    #     player[:tracking] = enemy
-    #     true  # This will remove the enemy from the array
-    #   else
-    #     false  # This will keep the enemy in the array
-    #   end
-    # end
-    # player[:tracking] = enemies.sample if player[:hp] <= 0 # Player dies and last enemy is tracked
-
-    enemies = cheat_menu(player, enemies) # DEBUG CHEAT MENU
+    cheat_menu(player, enemies) # DEBUG CHEAT MENU
+    soul_checker(enemies, player)
     state_of_game(enemies, player)
   end
   game_over(player)


### PR DESCRIPTION
created second method to check for enemy deaths, same as original but now kept in a separate method outside of interface, which then chains a new method bounty that is shared with graveyard method. Both methods required currently as need a way to delete enemies per strike, with graveyard, but one on interface sor items and traps, with soul checker.