### PR TITLE
updated graveyard

### DIFF
--- a/assets/graveyard/enemy_graveyard.rb
+++ b/assets/graveyard/enemy_graveyard.rb
@@ -1,0 +1,34 @@
+# rubocop:disable all
+#-----------------------------YOUR CODE BELOW---------------------------------->
+
+enemies.reject! do |enemy|
+  if enemy[:hp] <= 0  # check for enemy deaths, update counter, track last enemy for game over
+    player[:kills] += 1
+    enemy_speaks(enemy, :pwned)
+    player[:tracking] = enemy
+    true  # This will remove the enemy from the array
+  else
+    false  # This will keep the enemy in the array
+  end
+end
+
+enemies.each_with_index do |current_enemy, index| # check for enemy deaths, update counter, track last enemy for game over
+  if current_enemy && current_enemy[:hp] <= 0
+    enemies_defeated += 1
+    enemy_speaks(current_enemy, :pwned)
+    tracked_enemy = current_enemy
+    enemies.delete_at(index) # Remove the defeated enemy from the array
+  end
+end
+
+def graveyard(enemies, hunter, target)
+  if target[:hp] <= 0  # check for enemy deaths, update counter, track last enemy for game over
+    enemy_speaks(target, :pwned)
+    if hunter[:id] == :player
+      bounty(hunter, target)
+      enemies.delete(target)
+    elsif target[:id] == :player
+      target[:tracking] = hunter
+    end
+  end
+end

--- a/interface.rb
+++ b/interface.rb
@@ -35,7 +35,7 @@ def play_game
     end
 
     cheat_menu(player, enemies) # DEBUG CHEAT MENU
-    soul_checker(enemies, player)
+    graveyard(enemies, player)
     state_of_game(enemies, player)
   end
   game_over(player)


### PR DESCRIPTION
Updated graveyard method, don't need 2 after all. The new graveyard had a feature that it tracks the enemy who dealt lethal and sends a pwned message to player, so that player is treated same as enemy. 
Old graveyard takes only 2 parameters, player and enemies  which are routed everywhere (unlike hunter and target ), so it can be called from anywhere. Graveyard is called on strikes and end of loop so it takes care of all types of deaths.
added conditional in strike that simply checks if target is player and if they died then sends the same pwned message and updates tracker to lethal dealer 