### PR TITLE
Back to items

### DIFF
--- a/main/attack_mode.rb
+++ b/main/attack_mode.rb
@@ -38,7 +38,7 @@ def strike(enemies, hunter, target)                        # dynamic damage mult
   end
 
   weapon_breaks(hunter) if hunter[:weapon]
-  graveyard(enemies, (hunter[:id] == :player ? hunter : target)) # graveyard checks for enemy deaths and collects bounty
+  graveyard(enemies, (hunter[:id] == :player ? hunter : target)) # checks for enemy deaths and collects bounty
 
   if target[:id] == :player && target[:hp] <= 0
     target[:tracking] = hunter   # if player dies tracks enemy who dealt lethal blow
@@ -50,13 +50,13 @@ end
 
 def somersault(chance, n)
   success = "#{SUCCESS} " + "⚔️ " * n
-  failed = "#{FLUNKED} " + "😓 " * n
+  failed  = "#{FLUNKED} " + "😓 " * n
 
   messages = chance == 1 ? success : failed
   puts text_break(messages, " ", 85)
 end
 
-def somersault_attack(player, enemies)   # succeed and strike twice, fail and get struck thrice
+def somersault_attack(player, enemies) # winner strikes loser 2-3 times, targets random
   chance = rand(2)
   n = rand(2..3)
   somersault(chance, n)
@@ -114,7 +114,7 @@ def bounty(hunter, target)
   invoice(hunter, 0, :bounty) # amounts hardcoded as they're static
 end
 
-def graveyard(enemies, player) # graveyard checks for enemy deaths and collects bounty
+def graveyard(enemies, player)
   enemies.reject! do |enemy|
     if enemy[:hp] <= 0  # check for enemy deaths, update counter, track last enemy for game over
       enemy_speaks(enemy, :pwned)

--- a/main/war_machine.rb
+++ b/main/war_machine.rb
@@ -31,18 +31,18 @@ def random_enemy
 end
 
 def crap_factory(enemies, player)
-  buffs = [:hp, :xattack, :xblock, :xaim, :xchance]
+  buffs  = [:hp, :xattack, :xblock, :xaim, :xchance]
   target = [player, enemies.sample].sample
-  buff = buffs.sample
+  buff   = buffs.sample
 
   target[buff] ||= 0  # Initialize the key if it doesn't exist, then accumulate the boost
-  boost = (rand(1..2) * [1, -1].sample)
+  boost = [1, -1].sample
   gains = boost.positive? ? :item : :trap # set outcome
-  target[buff] += boost # apply boost
 
   if buff == :hp
     invoice(target, buff, gains)
   else
+    target[buff] += boost # apply boost
     invoice(target, buff, gains)
   end
 end

--- a/main/war_machine.rb
+++ b/main/war_machine.rb
@@ -31,19 +31,18 @@ def random_enemy
 end
 
 def crap_factory(enemies, player)
-  buffs  = [:hp, :xattack, :xblock, :xaim, :xchance]
-  target = [player, enemies.sample].sample
-  buff   = buffs.sample
-
-  target[buff] ||= 0  # Initialize the key if it doesn't exist, then accumulate the boost
-  boost = [1, -1].sample
-  gains = boost.positive? ? :item : :trap # set outcome
+  buff   = [:hp, :xattack, :xblock, :xaim, :xchance].sample
+  target = [player,                  enemies.sample].sample
 
   if buff == :hp
-    invoice(target, buff, gains)
+    hp = rand(5..12) * [1, -1].sample
+    invoice(target, hp, buff)
   else
+    target[buff] ||= 0  # Initialize the key if it doesn't exist, then accumulate the boost
+    boost = [1, -1].sample
+    item  = boost.positive? ? :item : :trap # set outcome
     target[buff] += boost # apply boost
-    invoice(target, buff, gains)
+    invoice(target, buff, item)
   end
 end
 

--- a/messages/invoice.rb
+++ b/messages/invoice.rb
@@ -3,7 +3,7 @@
 
 # Invoice for stat changes
 
-def invoice(who, what, where)
+def invoice(who, what, why)
   # item = who[:pouch].last # last added item
   # item[:tag] = if item[:stat] == :attack || item[:stat] == :block # checks if item is attack/block
   #   item[:type] == :trap ? BUFFS[item[:stat]][:minus] : BUFFS[item[:stat]][:plus] # attack/block can be positive/negative
@@ -15,7 +15,7 @@ def invoice(who, what, where)
   # item_tag   = who[:id] == :player ?            "#{ITEM}"           :             "#{THIEF}"
   # trap_tag   = who[:id] == :player ?            "#{DEBT}"           :             "#{TRAP}"
 
-  x, messages = case where
+  x, messages = case why
   when :bounty then [90, "#{BONUS} #{who[:name]} +10 #{who[:emoji]} + 1 💵"]
   when :item   then [90, "#{item_tag} #{who[:name]} #{pouch_item}"]
   when :trap   then [90, "#{trap_tag} #{who[:name]} #{pouch_trap}"]


### PR DESCRIPTION
have to pull and merge progress so far, had another epiphany
wrote basic method where a stat is selected, if hp applied differently then other stats get +1/-1, this is stored as a new key and the idea is to apply and reset all of them on first combat.
I then realised items should be identical to weapons, new hashes with matching keys are created and stored in the player, making them easy to apply to existing combat logic