### PR TITLE
Better menu

### DIFF
--- a/assets/ascii.rb
+++ b/assets/ascii.rb
@@ -80,7 +80,7 @@ PWNED     = "#{RD}☠️𝕡𝕨𝕟𝕖𝕕#{CL}"
 CARD      = "#{OR}ⲤⲀꞄⲆ#{CL}"
 BLACKJACK = "#{OR}🎌 乃㇄闩⼕长丿闩⼕长 🎌#{CL}"
 REVEAL    = "#{BL}DͩEͤAͣLEͤRͬ👁️‍🗨️RͬEͤVͮEͤAͣL#{CL}"
-
+TARGET    = "#{OR}🎯 ㇄龱⼕长 龱𝓝#{CL}"
 
 # Incase I need them later
 # TRAP      = "#{YL}ƬᖇᎯᕈ🪤#{CL}"

--- a/display/menu.rb
+++ b/display/menu.rb
@@ -5,50 +5,51 @@ def load_menu(player, menu)
   if menu == :main
     puts " " * 30 + "#{ML}𝕎ℍ𝔸𝕋ℂℍ𝔸 𝔾𝕆ℕℕ𝔸 𝔻𝕆❔#{CL}"
     puts " " * 23 + "🥷 #{RD}[̼̟̞T͍̦͔]̻̟͜S͛ᴛⷮRͬIͥᴋⷦEͤ#{CL}"
-    puts " " * 23 + "🐬 #{YL}[͌̈́͘R͌̈́͆]͋͑͠Sᴏᴍᴇʀsᴀᴜʟᴛ#{CL}" if player[:weapon] && player[:weapon][:bonus] == :somersault
+    puts " " * 23 + "🐬 #{YL}[͌̈́͘R͌̈́͆]͋͑͠#{ATTACKS[player[:weapon][:bonus]]}#{CL}" if player[:weapon] && player[:weapon][:bonus]
     puts " " * 23 + "💨 #{OR}[̻͓͜Y͖͖̘]̫̼͚Rͬoͦoͦmͫs͛#{CL}"
+    puts " " * 23 + "🎯 #{MG}[̳5̳-̳6̳]̳  ᑕჄᑕしᕮ Ꮆ〇〇Ɲ⟆#{CL}"
   elsif menu == :combat
     puts " " * 26 + "#{ML}丂卄ㄖ山 丫ㄖㄩ尺 爪ㄖᐯ🝗丂#{CL}"
     puts " " * 26 + "#{RD}#{NUM[4]}S͛ᴛⷮRͬIͥᴋⷦEͤ#{CL}"
     puts " " * 26 + "#{OR}#{NUM[5]}#{ATTACKS[player[:weapon][:bonus]]}#{CL}"
   elsif menu == :style
     puts " " * 28 + "#{ML}ℬℯ 𝓅𝓇ℴ𝒻ℯ𝓈𝓈𝒾ℴ𝓃𝒶𝓁𝓁𝓎 ℊℴℴ𝒹 𝓁ℴℴ𝓀𝒾𝓃ℊ...#{CL}"
-    puts " " * 26 + "#{CN}#{NUM[4]} 🧊 𝔹𝕝𝕦𝕖𝕊𝕥𝕖𝕖𝕝#{CL}"
-    puts " " * 26 + "#{OR}#{NUM[5]} 🐯 Lᴇ Tɪɢʀᴇ#{CL}"
-    puts " " * 26 + "#{MG}#{NUM[6]} 🍦 𝕄𝔸𝔾ℕ𝕌𝕄#{CL}"
+    puts " " * 26 + "#{CN}#{NUM[5]} 🧊 𝔹𝕝𝕦𝕖𝕊𝕥𝕖𝕖𝕝#{CL}"
+    puts " " * 26 + "#{OR}#{NUM[6]} 🐯 Lᴇ Tɪɢʀᴇ#{CL}"
+    puts " " * 26 + "#{MG}#{NUM[7]} 🍦 𝕄𝔸𝔾ℕ𝕌𝕄#{CL}"
   elsif menu == :match
     puts " " * 28 + "#{ML}Ⲥⲏⲟⲟ𝛓ⲉ ⲩⲟ𐌵ꞅ ⲣⲟⲕⲉⲙⲟⲛ#{CL}"
-    puts " " * 26 + "#{RD}#{NUM[4]} 🦎𝕮𝖍𝖆𝖗𝖒𝖆𝖓𝖉𝖊𝖗🔥#{CL}"
-    puts " " * 26 + "#{BL}#{NUM[5]} 🐢 𝒮𝓆𝓊𝒾𝓇𝓉𝓁ℯ 💧#{CL}"
+    puts " " * 26 + "#{RD}#{NUM[5]} 🦎𝕮𝖍𝖆𝖗𝖒𝖆𝖓𝖉𝖊𝖗🔥#{CL}"
+    puts " " * 26 + "#{BL}#{NUM[6]} 🐢 𝒮𝓆𝓊𝒾𝓇𝓉𝓁ℯ 💧#{CL}"
   elsif menu == :play
     puts " " * 26 + "#{ML}поиграй в игру сука#{CL}"
-    puts " " * 26 + "#{GN}#{NUM[4]} 🃏 Давай!#{CL}"
-    puts " " * 26 + "#{RD}#{NUM[5]} 🪂 Пиздᴇц!#{CL}"
+    puts " " * 26 + "#{GN}#{NUM[5]} 🃏 Давай!#{CL}"
+    puts " " * 26 + "#{RD}#{NUM[6]} 🪂 Пиздᴇц!#{CL}"
   elsif menu == :replay
     puts " " * 28 + "#{ML}xᴏᴘᴏᴡᴀя игᴘᴀ, ᴋᴀᴋ xᴏчᴇᴡь ᴇщᴇ ᴏдʜʏ?#{CL}"
-    puts " " * 26 + "#{GN}#{NUM[4]} 🎰 Eщё!#{CL}"
-    puts " " * 26 + "#{RD}#{NUM[5]} 💨 ᴏтʙᴀли!#{CL}"
+    puts " " * 26 + "#{GN}#{NUM[5]} 🎰 Eщё!#{CL}"
+    puts " " * 26 + "#{RD}#{NUM[6]} 💨 ᴏтʙᴀли!#{CL}"
   end
   puts BARRIER
 end
 
 def show_your_moves(player, the_boss, user_moves, boss_moves, menu)
   moves = {
-    4 => "#{CN}🧊 𝔹𝕝𝕦𝕖𝕊𝕥𝕖𝕖𝕝#{CL}",
-    5 => "#{OR}🐯 Lᴇ Tɪɢʀᴇ #{CL}",
-    6 => "#{MG}🍦 𝕄𝔸𝔾ℕ𝕌𝕄   #{CL}"
+    5 => "#{CN}🧊 𝔹𝕝𝕦𝕖𝕊𝕥𝕖𝕖𝕝#{CL}",
+    6 => "#{OR}🐯 Lᴇ Tɪɢʀᴇ #{CL}",
+    7 => "#{MG}🍦 𝕄𝔸𝔾ℕ𝕌𝕄   #{CL}"
   }
   pkmn = {
-    4 => "#{RD}🦎𝕮𝖍𝖆𝖗𝖒𝖆𝖓𝖉𝖊𝖗🔥#{CL}",
-    5 => "#{BL}🐢 𝒮𝓆𝓊𝒾𝓇𝓉𝓁ℯ 💧#{CL}"
+    5 => "#{RD}🦎𝕮𝖍𝖆𝖗𝖒𝖆𝖓𝖉𝖊𝖗🔥#{CL}",
+    6 => "#{BL}🐢 𝒮𝓆𝓊𝒾𝓇𝓉𝓁ℯ 💧#{CL}"
   }
 
   if menu == :style
     boss_moves.each_with_index do |boss, round|
       user = user_moves[round]
       x = case
-      when (user == 4 && boss == 6) then SUCCESS
-      when (user == 6 && boss == 4) then FLUNKED
+      when (user == 5 && boss == 7) then SUCCESS
+      when (user == 7 && boss == 5) then FLUNKED
       when user > boss then SUCCESS
       when user < boss then FLUNKED
       else "🍃 #{MISS}  🍂"

--- a/games/blackjack.rb
+++ b/games/blackjack.rb
@@ -11,11 +11,11 @@ def blackjack(enemies, player, dealer)
       blackjack_menu(enemies, dealer, player, :play)
       player[:choice] = gets.chomp.to_i
 
-      if player[:choice] == 4
+      if player[:choice] == 5
         print `clear`
         draw_card(player, player) # second argument required as player holds the deck, and dealer needs to access it
         shout(player, :cards)
-      elsif player[:choice] == 5
+      elsif player[:choice] == 6
         player[:stuck] = true
         break
       else shout(dealer, :error)
@@ -36,8 +36,8 @@ def blackjack(enemies, player, dealer)
       blackjack_menu(enemies, dealer, player, :replay)
       play_again = gets.chomp.to_i
       case play_again
-      when 4 then break # play again
-      when 5
+      when 5 then break # play again
+      when 6
         print `clear`
         shout(dealer, :goodbye)
         player[:land] = { id: :move, art: BATTLEFIELD.sample } # reset art back to main menu

--- a/interface.rb
+++ b/interface.rb
@@ -10,6 +10,7 @@ def play_game(player)
   player[:tracks] = enemies.sample
   shout(player, :intro)
   game_info(enemies, player)
+  index = 0
 
   while !enemies.empty? && player[:hp].positive?
     load_menu(player, :main)
@@ -17,11 +18,14 @@ def play_game(player)
 
     print `clear`
     case player[:choice]
-    when "t" then mortal_kombat(enemies, player)
+    when "5" then index = (index - 1) % enemies.length
+    when "6" then index = (index + 1) % enemies.length
+    when "t" then brawl(enemies, player, enemies[index])
     when "r" then player[:weapon] && player[:weapon][:bonus] == :somersault ? somersault(enemies, player) : shout(player, :error)
     when "y" then escape_room(enemies, player)
     else shout(player, :error)
     end
+    target = enemies[index]
 
     player[:land] = { id: :move, art: BATTLEFIELD.sample } # resets ASCII art to this arena
     cheat_mode(enemies, player) # DEBUG CHEAT MENU

--- a/interface.rb
+++ b/interface.rb
@@ -10,7 +10,7 @@ def play_game(player)
   player[:tracks] = enemies.sample
   shout(player, :intro)
   game_info(enemies, player)
-  index = 0
+  target = 0
 
   while !enemies.empty? && player[:hp].positive?
     load_menu(player, :main)
@@ -18,14 +18,13 @@ def play_game(player)
 
     print `clear`
     case player[:choice]
-    when "5" then index = (index - 1) % enemies.length
-    when "6" then index = (index + 1) % enemies.length
-    when "t" then brawl(enemies, player, enemies[index])
+    when "5" then target = (target - 1) % enemies.length; shout(enemies[target], :target)
+    when "6" then target = (target + 1) % enemies.length; shout(enemies[target], :target)
+    when "t" then brawl(enemies, player, enemies[target])
     when "r" then player[:weapon] && player[:weapon][:bonus] == :somersault ? somersault(enemies, player) : shout(player, :error)
     when "y" then escape_room(enemies, player)
     else shout(player, :error)
     end
-    target = enemies[index]
 
     player[:land] = { id: :move, art: BATTLEFIELD.sample } # resets ASCII art to this arena
     cheat_mode(enemies, player) # DEBUG CHEAT MENU

--- a/main/shout.rb
+++ b/main/shout.rb
@@ -35,6 +35,7 @@ def shout(who, what) # controls all messages in the game except for combat
   when :counter  then [100,          COUNTER    +   " "  + who[:name] + " 🗯️ " +  COUNTER_SHOUT.sample ]
   when :combat   then [100,          COMBAT     +   " "  + who[:name] + " 🗯️ " +   COMBAT_SHOUT.sample ]
   when :gamblore then [ 90,   ATTACKS[:gambler] +   " "  + who[:name] + " 🗯️ " +     GAME_SHOUT.sample ]
+  when :target   then [ 90,          TARGET     +   " "  + who[:name] ]
   when :used     then [ 80, item_used(who)]
   end
   print `clear` if [:name, :error].include?(what)


### PR DESCRIPTION
I don't know why my best ideas come to me immediately after I waste my time implementing my worst one.
Originally the game were to have too many nested interfaces for making small decisions which I don't like. You select combat, then you select  an enemy, then strike. If you have a special move the process would be select combat, select an enemy, select a move then go to final interface again to make your decisions during the special move. This means a total of 4 nested interfaces just for 1 attack that could instantly fail and then back to 4 menus again.

I have implemented a target system in the main interface to cycle through enemies using 5 and 6 and then selecting your move. This means all special moves can now be displayed and selected through the main interface and I can kill 2 no longer needed interfaces. A pop up message shows up displaying your current target.

will now clean up and delete unused code in a new branch