### PR TITLE
Upgrade rooms

### DIFF
--- a/assets/cheat_mode.rb
+++ b/assets/cheat_mode.rb
@@ -14,7 +14,7 @@ def cheat_mode(enemies, player, target)
   when "f" then player[:drunk]         -=   1
   when "d" then player[:drunk]         +=   1
   when "g" then player[:kills]         +=   1
-  when "v" then player[:rooms]         +=   1
+  when "v" then player[:scout]         +=   1
   when "k" then player[:attack]        +=  10; player[:aim] = 10
   when "h" then player[:weapon][:uses] +=   1 if player[:weapon]
   when "j" then weapon_breaks(player)         if player[:weapon]

--- a/display/display.rb
+++ b/display/display.rb
@@ -76,10 +76,10 @@ def status(player) # Dynamic status for player cash & drunkness
     end
 
   s1 = player[:kills] < 10 ? " " : "" # creating leading whitespace instead of leading zero
-  s2 = player[:rooms] < 10 ? " " : ""
+  s2 = player[:scout] < 10 ? " " : ""
 
   left = " " * 3 + "#{GN}#{wallet} #{CL}#{"💵" * [player[:cash], 0].max}" + "💷" * [0, (5 - player[:cash])].max + " " * 4 +
-  "💀#{s1}#{player[:kills]}  🏰#{s2}#{player[:rooms]}"
+  "💀#{s1}#{player[:kills]}  🏰#{s2}#{player[:scout]}"
   puts STATUS_BAR
   puts "#{left}#{OR}#{drunk}#{CL} #{"🍺" * [player[:drunk], 0].max}"
 end

--- a/display/menu.rb
+++ b/display/menu.rb
@@ -56,7 +56,7 @@ def show_your_moves(player, target, menu)
       when (you == 7 && them == 5) then FLUNKED
       when you > them then SUCCESS
       when you < them then FLUNKED
-      else "🍃 #{MISS}  🍂"
+      else "🍃 #{MISS}  🍂" # reusing this tag but need to pad it out with emojis
       end
       puts whitespace(player, " ", 14) + "#{player[:name]} 💬 #{style[you]} #{x} #{style[them]} 🗨️ #{target[:name]}"
     end

--- a/main/attack_mode.rb
+++ b/main/attack_mode.rb
@@ -72,7 +72,8 @@ end
 def bounty(hunter, target) # collect bounty
   hunter[:tracks] = target
   hunter[:kills] += 1
-  hunter[:cash]   = (hunter[:cash] + 1).clamp(0, 5)
-  hunter[:hp]     = (hunter[:hp] + 10).clamp(0, 150)
+  hunter[:cash]   = (hunter[:cash]  + 1).clamp(0,   5)
+  hunter[:drunk]  = (hunter[:drunk] - 1).clamp(0,   5)
+  hunter[:hp]     = (hunter[:hp]   + 10).clamp(0, 100)
   shout(hunter, :bounty) # amounts hardcoded as they're static
 end

--- a/main/escape_room.rb
+++ b/main/escape_room.rb
@@ -3,32 +3,36 @@
 
 def escape_room(enemies, player)
   choice = 0
-  rooms  = room_vault(4)
-  player[:land] = { id: :room, art: ROOM_SERVICE.sample }
+  n = (6 - player[:drunk]).clamp(1, 4) # fewer rooms available if player drunk
+  player[:rooms]  = room_vault(n) # creates n room
+  player[:land] = { id: :room, art: ROOM_SERVICE.sample } # sets the scene
   shout(player, :escape)
   game_info(enemies, player)
 
-  until (4..7).include?(choice) # index +4 / -4 to set user choice to (4..7) instead of (0..3)
+  until ((4..(4 + player[:rooms].length - 1)).include?(choice))
     puts MENU_HEADER
-    rooms.each_with_index { |room, i| puts " " * 22 + "#{ML}#{NUM[i + 4]}#{CL} #{room[:name]}" }
+    player[:rooms].each_with_index { |room, i| puts " " * 22 + "#{ML}#{NUM[i + 4]}#{CL} #{room[:name]}" }
     puts BARRIER
-
     choice = gets.chomp.to_i
-    shout(player, :error)      unless (4..7).include?(choice)
-    game_info(enemies, player) unless (4..7).include?(choice)
+
+    shout(player, :error)      # unless (4..7).include?(choice)
+    game_info(enemies, player) # unless (4..7).include?(choice)
   end
 
   print `clear`
-  player[:room]   = rooms[choice - 4]
-  player[:rooms] += 1
-  player[:roll]   = player[:room][:chance].sample
-  target          = [player, enemies.sample].sample
+  player[:room]   = player[:rooms][choice - 4]
+  #p player[:rooms]
+  player[:scout] += 1 # updates visited counter
+  player[:drunk].times { player[:room][:chance] << 3 } # 1 extra chance to meet an enemy per level of drunk
+  player[:roll]   = player[:room][:chance].sample # final outcome is then sampled
+  p player[:room] # DEBUG
   shout(player, :room)
 
   case player[:roll]
-  when 1 then crap_factory(target)
-  when 2 then weapon_wakes(target)
+  when 1 then crap_factory(player)
+  when 2 then weapon_wakes(player)
   when 3 then spawn_enemy(enemies, player)
   end
+  target          = [player, enemies.sample].sample
   surprise(enemies, player)
 end

--- a/main/escape_room.rb
+++ b/main/escape_room.rb
@@ -12,6 +12,7 @@ def escape_room(enemies, player)
     player[:choice] = gets.chomp.to_i
     shout(player, :error)
   end
+
   print `clear`
   open_door(player)
 
@@ -20,8 +21,7 @@ def escape_room(enemies, player)
   when 2 then weapon_wakes(player)
   when 3 then spawn_enemy(enemies, player)
   end
-  target          = [player, enemies.sample].sample
-  surprise(enemies, player)
+  parting_gift(enemies, player)
 end
 
 def run_away(player)
@@ -38,4 +38,12 @@ def open_door(player)
   player[:drunk].times { player[:room][:chance] << 3 } # 1 extra chance to meet an enemy per level of drunk
   player[:roll]   = player[:room][:chance].sample # final outcome is then sampled
   shout(player, :room)
+end
+
+def parting_gift(enemies, player)
+  player[:drunk] = (player[:drunk] + 1).clamp(0, 5) if rand(2) == 1
+  if rand(2) == 1
+    rand(2) == 1 ? crap_factory(enemies.sample) : weapon_wakes(enemies.sample)
+  end
+  surprise(enemies, player)
 end

--- a/main/escape_room.rb
+++ b/main/escape_room.rb
@@ -2,32 +2,18 @@
 #-----------------------------YOUR CODE BELOW---------------------------------->
 
 def escape_room(enemies, player)
-  choice          = 0
-  n               = (6 - player[:drunk]).clamp(1, 4) # fewer rooms available if player drunk
-  player[:rooms]  = room_vault(n) # creates n room
-  player[:land]   = { id: :room, art: ROOM_SERVICE.sample } # sets the scene
+  run_away(player)
 
-  shout(player, :escape)
-  game_info(enemies, player)
-
-  until (4..(3 + player[:rooms].length)).include?(choice) # 4..(3 + rooms length are set to the indexes are 4-7 instead of 0-3
+  until (4..(3 + player[:rooms].length)).include?(player[:choice]) # 4..(3 + rooms length are set to the indexes are 4-7 instead of 0-3
+    game_info(enemies, player)
     puts MENU_HEADER
     player[:rooms].each_with_index { |room, i| puts " " * 22 + "#{ML}#{NUM[i + 4]}#{CL} #{room[:name]}" } # +4 to index
     puts BARRIER
-    choice = gets.chomp.to_i
-
-    shout(player, :error)      # unless (4..7).include?(choice)
-    game_info(enemies, player) # unless (4..7).include?(choice)
+    player[:choice] = gets.chomp.to_i
+    shout(player, :error)
   end
-
   print `clear`
-  player[:room]   = player[:rooms][choice - 4] # -4 to correct index
-  #p player[:rooms]
-  player[:scout] += 1 # updates visited counter
-  player[:drunk].times { player[:room][:chance] << 3 } # 1 extra chance to meet an enemy per level of drunk
-  player[:roll]   = player[:room][:chance].sample # final outcome is then sampled
-  p player[:room] # DEBUG
-  shout(player, :room)
+  open_door(player)
 
   case player[:roll]
   when 1 then crap_factory(player)
@@ -36,4 +22,20 @@ def escape_room(enemies, player)
   end
   target          = [player, enemies.sample].sample
   surprise(enemies, player)
+end
+
+def run_away(player)
+  player[:choice] = 0
+               n  = (6 - player[:drunk]).clamp(1, 4) # fewer rooms available if player drunk
+  player[:rooms]  = room_vault(n) # creates n room
+  player[:land]   = { id: :room, art: ROOM_SERVICE.sample } # sets the scene
+  shout(player, :escape)
+end
+
+def open_door(player)
+  player[:room]   = player[:rooms][player[:choice] - 4] # -4 to correct index
+  player[:scout] += 1 # updates visited counter
+  player[:drunk].times { player[:room][:chance] << 3 } # 1 extra chance to meet an enemy per level of drunk
+  player[:roll]   = player[:room][:chance].sample # final outcome is then sampled
+  shout(player, :room)
 end

--- a/main/escape_room.rb
+++ b/main/escape_room.rb
@@ -2,16 +2,17 @@
 #-----------------------------YOUR CODE BELOW---------------------------------->
 
 def escape_room(enemies, player)
-  choice = 0
-  n = (6 - player[:drunk]).clamp(1, 4) # fewer rooms available if player drunk
+  choice          = 0
+  n               = (6 - player[:drunk]).clamp(1, 4) # fewer rooms available if player drunk
   player[:rooms]  = room_vault(n) # creates n room
-  player[:land] = { id: :room, art: ROOM_SERVICE.sample } # sets the scene
+  player[:land]   = { id: :room, art: ROOM_SERVICE.sample } # sets the scene
+
   shout(player, :escape)
   game_info(enemies, player)
 
-  until ((4..(4 + player[:rooms].length - 1)).include?(choice))
+  until (4..(3 + player[:rooms].length)).include?(choice) # 4..(3 + rooms length are set to the indexes are 4-7 instead of 0-3
     puts MENU_HEADER
-    player[:rooms].each_with_index { |room, i| puts " " * 22 + "#{ML}#{NUM[i + 4]}#{CL} #{room[:name]}" }
+    player[:rooms].each_with_index { |room, i| puts " " * 22 + "#{ML}#{NUM[i + 4]}#{CL} #{room[:name]}" } # +4 to index
     puts BARRIER
     choice = gets.chomp.to_i
 
@@ -20,7 +21,7 @@ def escape_room(enemies, player)
   end
 
   print `clear`
-  player[:room]   = player[:rooms][choice - 4]
+  player[:room]   = player[:rooms][choice - 4] # -4 to correct index
   #p player[:rooms]
   player[:scout] += 1 # updates visited counter
   player[:drunk].times { player[:room][:chance] << 3 } # 1 extra chance to meet an enemy per level of drunk

--- a/main/shout.rb
+++ b/main/shout.rb
@@ -23,7 +23,7 @@ def shout(who, what) # controls all messages in the game except for combat
   when :outro    then [ 80, who[:tracks][:name] +   " "  + (who[:hp].positive? ? WIN_SHOUT : LOSE_SHOUT).sample ]
   when :escape   then [ 80,          who[:name] + " 💬 " + RUN_SHOUT.sample ]
   when :room     then [ 80,          who[:name] + " 💬 " + ROOM_SHOUT.sample  + " " +  who[:room][:name] ]
-  when :bounty   then [ 90,          BONUS      +   " "  + who[:name] + " +10 "+       who[:emoji]         + " +1 💵" ]
+  when :bounty   then [ 90,          BONUS      +   " "  + who[:name] + " +10 "+       who[:emoji]         + " +1 💵" + " -1 🍺"]
   when :cards    then [110,          CARD       +   " "  + who[:name] +  " "   +       who[:hand].last[:suit] ]
   when :broke    then [ 90,          BROKE      +   " "  + who[:name] +  "'s"  + " " + who[:weapon][:name] +  " "   + BROKE_SHOUT.sample ]
   when :item     then [ 90,          tag        +   " "  + who[:item][:name]   + " " + who[:name]          + " 💬 " +  ITEM_SHOUT.sample ]

--- a/main/war_machine.rb
+++ b/main/war_machine.rb
@@ -13,7 +13,7 @@ def wake_up
     cash:     0,
     drunk:    0,
     kills:    0,
-    rooms:    0,
+    scout:    0,
   }
 end
 


### PR DESCRIPTION
updates room logic
> enemies no longer steal player weapon or items, every outcome is generated solely for player
> enemies run their own method at the end which can involve a 50% chance of  a random enemy acquiring a weapon or item
> drunk system reconfigured back into game. Player has a 50% of getting more drunk each time they visit a room. For now this can only be removed with kills, will see later if will implement other ways to remove based on balance
> each level of drunk decreases number of rooms you can visit, it starts with 4 rooms max and decreases by 1 once u reach 3 drunk down to a minimum of 1
> each level of drunk adds a 3 integer to the entered room array, meaning 5 drunk means 5 more chances of encountering an enemy