### PR TITLE
Refactor

### DIFF
--- a/assets/ascii.rb
+++ b/assets/ascii.rb
@@ -46,7 +46,7 @@ BUFFS = {
   :attack => "#{RD}𝙍𝘼𝙂𝙀#{CL}",
   :aim    => "#{BL}🆂🅽🅸🅿🅴🆁#{CL}",
   :chance => "#{OR}ⲥꞅⲓⲧ%#{CL}",
-  :crit   => "#{MG}ⲤꞅⲓⲧⲬ#{CL}",
+  :crit   => "#{MG}ⲤꞅⲓⲧⲬ#{CL}"
 }
 
 ATTACKS = {
@@ -54,7 +54,13 @@ ATTACKS = {
   :somersault => "#{YL}Sᴏᴍᴇʀsᴀᴜʟᴛ#{CL}",
   :stylish    => "#{CN}🆂🆃🆈🅻🅸🆂🅷#{CL}",
   :psychic    => "#{MG}𝙋𝙎𝙮𝘾𝙝𝙞𝙘#{CL}",
-  :sneaky     => "#{BL}S̷N̷E̷A̷K̷Y̷#{CL}",
+  :sneaky     => "#{BL}S̷N̷E̷A̷K̷Y̷#{CL}"
+}
+
+SHOTS = {
+  :hit  => "#{RD}⚔️ 𝙷𝙸𝚃 💢#{CL}",
+  :crit => "#{OR}⚔️ 𝙲𝚁𝙸𝚃𝙸𝙲𝙰𝙻 💥#{CL}",
+  :miss => "#{BL}𝙼𝙸𝚂𝚂💤#{CL}"
 }
 
 NUM       = ["[̼̟̞0̳  ]̻̟͜", "[̼̟̞1̳  ]̻̟͜", "[̼̟̞2̳  ]̻̟͜", "[̼̟̞3̳  ]̻̟͜", "[̼̟̞4̳  ]̻̟͜", "[̼̟̞5̳  ]̻̟͜", "[̼̟̞6̳  ]̻̟͜", "[̼̟̞7̳  ]̻̟͜", "[̼̟̞8̳  ]̻̟͜", "[̼̟̞9̳  ]̻̟͜"]
@@ -71,12 +77,10 @@ BROKE     = "#{RD}𝐁𝐑𝐎𝐊𝐄💔#{CL}"
 POW       = "#{OR}👊🏼ℙ𝕆𝕎💥#{CL}"
 KABLAMO   = "#{RD}𝐾𝐴𝐵𝐿𝐴𝑀𝑂!💥#{CL}"
 TELEPORT  = "#{YL}✨ 𝘵𝘦𝘭𝘦𝘱𝘰𝘳𝘵𝘴#{CL}"
-CRIT      = "#{OR}⚔️ 𝙲𝚁𝙸𝚃𝙸𝙲𝙰𝙻 💥#{CL}"
-MISS      = "#{BL}𝙼𝙸𝚂𝚂💤#{CL}"
-HIT       = "#{RD}⚔️ 𝙷𝙸𝚃 💢#{CL}"
 COUNTER   = "#{BL}👊🏼ℂ𝕆𝕌ℕ𝕋𝔼ℝ#{CL}"
 SUCCESS   = "#{GN}🎈 𝓢𝓤𝓒𝓒𝓔𝓢𝓢 🎉#{CL}"
 FLUNKED   = "#{RD}🦨 ƑԼ𝓤ƝⲔƐƊ 🏳️#{CL}"
+NO_DICE   = "#{BL}⭕ 𝖭𝖮 𝖣𝖨𝖢𝖤 🎲#{CL}"
 SUMMON    = "#{MG}𝓢𝓟𝓐𝓦𝓝🪦#{CL}"
 SURPRISE  = "#{YL}⚡𝘚𝘜𝘙𝘗𝘙𝘐𝘚𝘌#{CL}"
 PWNED     = "#{RD}☠️𝕡𝕨𝕟𝕖𝕕#{CL}"

--- a/assets/phrases.rb
+++ b/assets/phrases.rb
@@ -1,18 +1,16 @@
 # rubocop:disable all
 #-----------------------------YOUR CODE BELOW---------------------------------->
 
-BACK_TALK = [
-  "Motherfucker! ", "Bugger it! ", "Bloody hell! ", "Arses! ", "Sod it! ", "Bollocks! ", "Shit! ", "I call hacks! "
-]
-TALK_BACK = [
-"Ha! What a douche!", "Ha! Did you miss me?", "Loser!", "Nice shot bro!", "What a joker!", "Clown"
-]
-FIGHT_TALK = [
-  "Ah yeah! ", "Bangers 'n' Mash u up!" "I own it! ", "Take that! ", "I'm jus' too good ", "Bow to me! ", "Ka-Blam! ", "Falcon Punch! "
-]
-FIGHT_BACK = [
-  "Hey, fuck you!", "You dick!", "What a shit..", "Hate that guy", "Ouch!", "What you do that for?", "Oooff!", "You fucker!"
-]
+FIGHTING_WORDS = {
+  :hit  => ["Ah yeah! ", "Bangers 'n' Mash u up! ", "I own it! ", "Take that! ", "I'm jus' too good ", "Bow to me! ", "Falcon Punch! "],
+  :crit => ["Blao! ", "Bam! ", "Ka-Pow! ", "Eat my wrath ", "You die now! ", "Smashed! ", "Ka-Blam! ", "Bye-bye! "],
+  :miss => ["Motherfucker! ", "Bugger it! ", "Bloody hell! ", "Arses! ", "Sod it! ", "Bollocks! ", "Shit! ", "I call hacks! "]
+}
+COMEBACKS = {
+  :hit  => ["Hey, fuck you!", "You dick!", "What a shit..", "Hate that guy", "Ouch!", "What you do that for?", "Oooff!", "You fucker!"],
+  :crit => ["You bastard!", "Noooooo!", "WTF!", "You cheating git!", "Imma get ya for that!", "Wanker!"],
+  :miss => ["Ha! What a douche!", "Ha! Did you miss me?", "Loser!", "Nice shot bro!", "What a joker!", "Clown", "Can't touch this!"]
+}
 ITEM_SHOUT = [
   "Delicious!", "Meh, eat it anyway", "Egh! Rank!", "Fucking A!", "What idiot left this here!",
   "5 second rule!", "Might as well", "Holy shit!", "This looks swell!", "Sweet as!", "Dinner sorted!",

--- a/display/menu.rb
+++ b/display/menu.rb
@@ -63,7 +63,7 @@ def show_your_moves(player, target, menu)
       when (you == 7 && them == 5) then FLUNKED
       when you > them then SUCCESS
       when you < them then FLUNKED
-      else "🍃  #{MISS} 🍂" # reusing this tag but need to pad it out with emojis
+      else NO_DICE
       end
       color = you == 5 ? BL : (you == 6 ? OR : MG)
       player[:screen]   = { id: :sticky, offset: 0, art: "#{color}#{MOVES[you]}#{CL}" } # sets the scene

--- a/interface.rb
+++ b/interface.rb
@@ -58,7 +58,7 @@ def ctrl_s(player) # player is saved on game over and can be used again on repla
   player          = player.dup
   player[:max_hp] = 99 + player[:level]
   player[:hp]     = player[:max_hp]
-  player[:screen]   = { id: :bounce, art: "#{RD}#{BATTLEFIELD.sample}#{CL}" }
+  player[:screen] = { id: :bounce, art: "#{RD}#{BATTLEFIELD.sample}#{CL}" }
   return player
 end
 
@@ -70,7 +70,7 @@ loop do
   loop do
     choice = gets.chomp.downcase
     case choice
-    when "n" then exit # Exit the program
+    when "n" then exit  # Exit the program
     when "y" then break # Restart the game
     else replay # end of game error screen
     end

--- a/main/attack_mode.rb
+++ b/main/attack_mode.rb
@@ -22,7 +22,7 @@ def strike(enemies, hunter, target) # all entities use this to fight
 
   if target[:id]   == :player && target[:hp] <= 0
     target[:tracks] = hunter   # if player dies tracks enemy who dealt lethal blow
-    target[:screen]   = { id: :flash, offset: 2, art: "#{RD}#{GAME_OVER}#{CL}" } # sets the scene
+    target[:screen] = { id: :flash, offset: 2, art: "#{RD}#{GAME_OVER}#{CL}" } # sets the scene
     shout(target, :pwned) # sends same pwned message to the player
   end
 end
@@ -44,7 +44,7 @@ end
 def shots_fired(hunter, target, shot) # Player vs enemy strike
   text = rand(3) == 1 ? (shot == :miss ? BACK_TALK.sample : "🗯️ " + FIGHT_TALK.sample) : ""
 
-  hit  = "#{hunter[:name]} #{text}#{HIT} #{target[:name]} #{target[:emoji]}-#{hunter[:damage]}"
+  hit  = "#{hunter[:name]} #{text}#{ HIT} #{target[:name]} #{target[:emoji]}-#{hunter[:damage]}"
   crit = "#{hunter[:name]} #{text}#{CRIT} #{target[:name]} #{target[:emoji]}-#{hunter[:damage]}"
   miss = "#{hunter[:name]} 🗯️❓ #{text}#{MISS} #{target[:name]}"
 
@@ -73,7 +73,7 @@ end
 
 def bounty(hunter, target) # collect bounty
   hunter[:tracks] = target
-  hunter[:xp] += 10
+  hunter[:xp]    += 10
   hunter[:cash]   = (hunter[:cash]  + 1).clamp(0,   5)
   hunter[:beers]  = (hunter[:beers] - 1).clamp(0,   5)
   hunter[:hp]     = (hunter[:hp]   + 10).clamp(0, hunter[:max_hp])

--- a/main/attack_mode.rb
+++ b/main/attack_mode.rb
@@ -63,7 +63,7 @@ def graveyard(enemies, player)
     if enemy[:hp] <= 0  # check for enemy deaths, update counter, track last enemy for game over
       shout(enemy, :pwned)
       bounty(player, enemy)
-      player[:screen]  = { id: :flash, offset: 4, art: "#{CN}#{ENEMY_PWNED}#{CL}" }
+      player[:screen] = { id: :flash, offset: 4, art: "#{CN}#{ENEMY_PWNED}#{CL}" }
       true  # This will remove the enemy from the array
     else false  # This will keep the enemy in the array
     end

--- a/main/attack_mode.rb
+++ b/main/attack_mode.rb
@@ -42,20 +42,14 @@ def load_ammo(hunter)
 end
 
 def shots_fired(hunter, target, shot) # Player vs enemy strike
-  text = rand(3) == 1 ? (shot == :miss ? BACK_TALK.sample : "🗯️ " + FIGHT_TALK.sample) : ""
+    shout = rand(3) ==   1   ? " #{FIGHTING_WORDS[shot].sample}"       : ""
+   damage =    shot != :miss ? " #{target[:emoji]}-#{hunter[:damage]}" : ""
+    emoji =    shot == :miss ? " 🗯️❓ "  :  (!shout.empty?  ?  " 🗯️ " : " ")
+     size =    shot == :crit ? 110 : 100
+  message = hunter[:name] + emoji + shout + SHOTS[shot] + " " + target[:name] + damage
 
-  hit  = "#{hunter[:name]} #{text}#{ HIT} #{target[:name]} #{target[:emoji]}-#{hunter[:damage]}"
-  crit = "#{hunter[:name]} #{text}#{CRIT} #{target[:name]} #{target[:emoji]}-#{hunter[:damage]}"
-  miss = "#{hunter[:name]} 🗯️❓ #{text}#{MISS} #{target[:name]}"
-
-  x, shout, comeback = case shot
-  when :hit  then [100, hit,  FIGHT_BACK]
-  when :crit then [110, crit, FIGHT_BACK]
-  when :miss then [100, miss,  TALK_BACK]
-  end
-
-  puts text_break(shout, " ", x)
-  puts text_break("#{target[:name]} 🗯️ #{comeback.sample}", " ", 85) if !text.empty? && rand(2) == 1
+  puts text_break(message, " ", size)
+  puts text_break("#{target[:name]} 🗯️ #{COMEBACKS[shot].sample}", " ", 85) if !shout.empty? && rand(2) == 1
 end
 
 def graveyard(enemies, player)

--- a/main/escape_room.rb
+++ b/main/escape_room.rb
@@ -28,7 +28,7 @@ def run_away(player)
   player[:choice] = 0
                n  = (6 - player[:beers]).clamp(1, 4) # fewer rooms available if player drunk
   player[:rooms]  = room_vault(n) # creates n rooms
-  player[:screen]   = { id: :sticky, offset: 15, art:  "#{ML}#{THE_DOOR.sample}#{CL}" } # sets the scene
+  player[:screen] = { id: :sticky, offset: 15, art:  "#{ML}#{THE_DOOR.sample}#{CL}" } # sets the scene
   shout(player, :escape)
 end
 
@@ -48,8 +48,8 @@ def parting_gift(enemies, player)
   if rand(2) == 1 # 50% for enemy to get item or weapon
     rand(2) == 1 ? crap_factory(enemies.sample) : weapon_wakes(enemies.sample, player)
   end
-  player[:screen]  = { id: :sticky, offset: 3, art: "#{YL}#{ROOM_SERVICE.sample}#{CL}" } # sets the scene
-  player[:shop]  = false #  shop is disabled each round whether accessed or not
-  player[:drain] = false
+  player[:screen] = { id: :sticky, offset: 3, art: "#{YL}#{ROOM_SERVICE.sample}#{CL}" } # sets the scene
+  player[:shop]   = false #  shop is disabled each round whether accessed or not
+  player[:drain]  = false
   surprise(enemies, player) unless (player[:weapon] && player[:weapon][:bonus] == :sneaky) # sneaky prevents surprise attacks
 end

--- a/main/war_machine.rb
+++ b/main/war_machine.rb
@@ -48,7 +48,7 @@ def room_vault(n)
   while rooms.length < n
     room = {
       name: ROOMS.sample,
-      chance: Array.new(rand(4..12)) { rand(1..3) } # creates an array with 4-12 integers, each with a value between 0-6
+      chance: Array.new(rand(4..12)) { rand(1..3) } # creates an array with 4-12 integers, values 1-3
     }
 
     # Check if the generated room's name is unique within the rooms array
@@ -56,7 +56,7 @@ def room_vault(n)
       rooms << room
     end
   end
-                                          # ANSI color hard coded here or all rooms get same color
+                                     # ANSI color hard coded here or all rooms get same color
   rooms.map { |room| room[:name] = "\e[3#{rand(1..6)}m#{DESC.sample} #{room[:name]}#{CL}" } # Give the rooms a unique desc
   rooms
 end
@@ -69,12 +69,12 @@ def weapon_wakes(wielder, player, order = nil)
 
   weapon = {
     name:  "#{name}#{CL}",
-    uses:   rand(uses),
+    uses:    rand(uses),
     attack: (rand(attack) + rand(1..player[:level])),
     block:  (rand(block)  + rand(1..player[:level])),
-    aim:    rand(aim),
-    chance: rand(chance),
-    crit:   rand(crit).round(1),
+    aim:     rand(aim),
+    chance:  rand(chance),
+    crit:    rand(crit).round(1),
     bonus:  bonus
   }
 


### PR DESCRIPTION
> I previously globally renamed a key and it made the spacing off - fixed it on several files but went on to refactor a method so will pull now
>Original shots fired method though very readable, very repetitive, it sets a case when and 3 variables with very little difference and repeat values. Instead refactored the tags and phrases into individual hashes with corresponding keys as  the tags and phrases. This way I only need to call on them only once like so HASH[:key] and whatever key is passed on will generate the correct ASCII tag or message.
Then I set several ternary operators to iron out the differences in between the varying message types.
>This way, the ascii.rb remains pretty much the same, the phrases.rb is cleaner and has half the variables and a few additional phrases and shits_fired method is overall shorter with no more repeating lines. It is still readable but now the tags are called on just once based on the key passed on rather than having to announce all 3 variables inside the method. Overall attack_mode.rb is now shorter and cleaner